### PR TITLE
refactor config methods, rename args, tweak descriptions

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -272,8 +272,8 @@ func startSmokescreen(t *testing.T, useTls bool) func() {
 	if useTls {
 		conf, err = Configure([]string{
 			"smokescreen",
-			"--server-ip=127.0.0.1",
-			fmt.Sprintf("--server-port=%d", plainSmokescreenPort),
+			"--listen-ip=127.0.0.1",
+			fmt.Sprintf("--listen-port=%d", plainSmokescreenPort),
 			"--egress-acl-file=testdata/sample_config.yaml",
 			"--danger-allow-access-to-private-ranges",
 			"--error-message-on-deny=\"egress denied: go see doc at https://example.com/egressproxy\"",
@@ -281,8 +281,8 @@ func startSmokescreen(t *testing.T, useTls bool) func() {
 	} else {
 		conf, err = Configure([]string{
 			"smokescreen",
-			"--server-ip=127.0.0.1",
-			fmt.Sprintf("--server-port=%d", tlsSmokescreenPort),
+			"--listen-ip=127.0.0.1",
+			fmt.Sprintf("--listen-port=%d", tlsSmokescreenPort),
 			"--egress-acl-file=testdata/sample_config.yaml",
 			"--danger-allow-access-to-private-ranges",
 			"--error-message-on-deny=\"egress denied: go see doc at https://example.com/egressproxy\"",

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -270,15 +270,17 @@ func startSmokescreen(t *testing.T, useTls bool) func() {
 	var conf *smokescreen.Config
 	var err error
 	if useTls {
-		conf, err = ConfigFromArgs(nil, []string{
+		conf, err = Configure([]string{
+			"smokescreen",
 			"--server-ip=127.0.0.1",
 			fmt.Sprintf("--server-port=%d", plainSmokescreenPort),
 			"--egress-acl-file=testdata/sample_config.yaml",
 			"--danger-allow-access-to-private-ranges",
 			"--error-message-on-deny=\"egress denied: go see doc at https://example.com/egressproxy\"",
-		})
+		}, nil)
 	} else {
-		conf, err = ConfigFromArgs(nil, []string{
+		conf, err = Configure([]string{
+			"smokescreen",
 			"--server-ip=127.0.0.1",
 			fmt.Sprintf("--server-port=%d", tlsSmokescreenPort),
 			"--egress-acl-file=testdata/sample_config.yaml",
@@ -287,7 +289,7 @@ func startSmokescreen(t *testing.T, useTls bool) func() {
 			"--tls-server-bundle-file=testdata/pki/server-bundle.pem",
 			"--tls-client-ca-file=testdata/pki/ca.pem",
 			"--tls-crl-file=testdata/pki/crl.pem",
-		})
+		}, nil)
 	}
 
 	a.NoError(err)

--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/stripe/smokescreen/cmd"
 	"github.com/stripe/smokescreen/pkg/smokescreen"
@@ -10,14 +8,13 @@ import (
 
 func main() {
 
-	conf, err := cmd.ConfigFromCli(nil)
+	conf, err := cmd.Configure(nil, nil)
 	if err != nil {
-		log.Print(err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 
 	if conf == nil {
-		os.Exit(1)
+		log.Fatal("No config")
 	}
 	smokescreen.StartWithConfig(conf, nil)
 }


### PR DESCRIPTION
Rename and tweak the description of various flags.  Also replace `ConfigFrom*` methods with a single `Configure` which takes args (including the command name, like `os.Args`, which is the default if you pass `nil`).